### PR TITLE
Update remark-html to ^12.0.0

### DIFF
--- a/api-routes-starter/package.json
+++ b/api-routes-starter/package.json
@@ -14,6 +14,6 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "remark": "^12.0.0",
-    "remark-html": "^11.0.1"
+    "remark-html": "^12.0.0"
   }
 }

--- a/basics-final/package.json
+++ b/basics-final/package.json
@@ -14,6 +14,6 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "remark": "^12.0.0",
-    "remark-html": "^11.0.1"
+    "remark-html": "^12.0.0"
   }
 }

--- a/demo/package.json
+++ b/demo/package.json
@@ -14,6 +14,6 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "remark": "^12.0.0",
-    "remark-html": "^11.0.1"
+    "remark-html": "^12.0.0"
   }
 }

--- a/typescript-final/package.json
+++ b/typescript-final/package.json
@@ -14,7 +14,7 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "remark": "^12.0.0",
-    "remark-html": "^11.0.1"
+    "remark-html": "^12.0.0"
   },
   "devDependencies": {
     "@types/node": "^13.11.0",


### PR DESCRIPTION
This pull request updates `remark-html` to `12.0.0`. There are no breaking changes
in the `12.0.0` release, but they have added type definitions, meaning
we can remove an unnecessary step in the TypeScript section.