### PR TITLE
typescript-final: fix compile error in Typescript strict mode

### DIFF
--- a/typescript-final/pages/posts/[id].tsx
+++ b/typescript-final/pages/posts/[id].tsx
@@ -39,7 +39,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 }
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
-  const postData = await getPostData(params.id as string)
+  const postData = await getPostData(params?.id as string)
   return {
     props: {
       postData


### PR DESCRIPTION
`typescript-final` example: fix the following compile error in Typescript strict mode

```bash
Failed to compile.

./pages/posts/[id].tsx:42:40
Type error: Object is possibly 'undefined'.

  40 |
  41 | export const getStaticProps: GetStaticProps = async ({ params }) => {
> 42 |     const postData = await getPostData(params.id as string)
     |                                        ^
  43 |     return {
  44 |         props: {
  45 |             postData
info  - Creating an optimized production build .npm ERR! code ELIFECYCLE
```