### PR TITLE
Update react and react-dom from 16.x to 17.0.1

### DIFF
--- a/learn-starter/package.json
+++ b/learn-starter/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "next": "^10.0.0",
-    "react": "16.13.1",
-    "react-dom": "16.13.1"
+    "react": "17.0.1",
+    "react-dom": "17.0.1"
   }
 }


### PR DESCRIPTION
I was running through the public tutorial at https://nextjs.org/learn/basics/create-nextjs-app/setup where you create a fresh app using:

```
npx create-next-app nextjs-blog --use-npm --example "https://github.com/vercel/next-learn-starter/tree/master/learn-starter"
```

When I ran `npm run dev` I saw this error in the console and the localhost:3000 page wouldn't load:
![image](https://user-images.githubusercontent.com/14899475/98502843-1403f180-2221-11eb-8723-9f209cce7947.png)

Updating react versions to 17.0.1 seems to fix the issue.