### PR TITLE
Destructuring to avoid repetition

### DIFF
--- a/dynamic-routes-step-1/pages/posts/[id].js
+++ b/dynamic-routes-step-1/pages/posts/[id].js
@@ -25,7 +25,7 @@ export async function getStaticProps({ params }) {
   const postData = getPostData(params.id)
   return {
     props: {
-      postData
+      ...postData
     }
   }
 }


### PR DESCRIPTION
Without destructuring you only access the properties of postData like this: postData.postData.id, postData.postData.title, etc.