### PR TITLE
update alternative text for Vercel logo to just "Vercel"

### DIFF
--- a/learn-starter/pages/index.js
+++ b/learn-starter/pages/index.js
@@ -55,7 +55,7 @@ export default function Home() {
           rel="noopener noreferrer"
         >
           Powered by{' '}
-          <img src="/vercel.svg" alt="Vercel Logo" className="logo" />
+          <img src="/vercel.svg" alt="Vercel" className="logo" />
         </a>
       </footer>
 


### PR DESCRIPTION
the former text was "Vercel logo"; however "logo" doesn't much make sense in the context of "Powered by **" phrase.

https://html.spec.whatwg.org/multipage/images.html#a-short-phrase-or-label-with-an-alternative-graphical-representation:-icons,-logos
https://webaim.org/techniques/alttext/#logos