### PR TITLE
Update next/react versions

### DIFF
--- a/api-routes-starter/package.json
+++ b/api-routes-starter/package.json
@@ -10,9 +10,9 @@
   "dependencies": {
     "date-fns": "^2.11.1",
     "gray-matter": "^4.0.2",
-    "next": "^10.0.0",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
+    "next": "^11.0.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "remark": "^12.0.0",
     "remark-html": "^12.0.0"
   }

--- a/assets-metadata-css-starter/package.json
+++ b/assets-metadata-css-starter/package.json
@@ -8,8 +8,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "^10.0.0",
-    "react": "17.0.1",
-    "react-dom": "17.0.1"
+    "next": "^11.0.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   }
 }

--- a/basics-final/package.json
+++ b/basics-final/package.json
@@ -10,9 +10,9 @@
   "dependencies": {
     "date-fns": "^2.11.1",
     "gray-matter": "^4.0.2",
-    "next": "^10.0.0",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
+    "next": "^11.0.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "remark": "^12.0.0",
     "remark-html": "^12.0.0"
   }

--- a/data-fetching-starter/package.json
+++ b/data-fetching-starter/package.json
@@ -8,8 +8,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "^10.0.0",
-    "react": "17.0.1",
-    "react-dom": "17.0.1"
+    "next": "^11.0.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   }
 }

--- a/demo/package.json
+++ b/demo/package.json
@@ -10,9 +10,9 @@
   "dependencies": {
     "date-fns": "^2.11.1",
     "gray-matter": "^4.0.2",
-    "next": "^10.0.0",
-    "react": "17.0.1",
-    "react-dom": "17.0.1",
+    "next": "^11.0.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "remark": "^12.0.0",
     "remark-html": "^12.0.0"
   }

--- a/dynamic-routes-starter/package.json
+++ b/dynamic-routes-starter/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "gray-matter": "^4.0.2",
-    "next": "^10.0.0",
-    "react": "17.0.1",
-    "react-dom": "17.0.1"
+    "next": "^11.0.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   }
 }

--- a/dynamic-routes-step-1/package.json
+++ b/dynamic-routes-step-1/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "gray-matter": "^4.0.2",
-    "next": "^10.0.0",
-    "react": "17.0.1",
-    "react-dom": "17.0.1"
+    "next": "^11.0.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   }
 }

--- a/learn-starter/package.json
+++ b/learn-starter/package.json
@@ -8,8 +8,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "^10.0.0",
-    "react": "17.0.1",
-    "react-dom": "17.0.1"
+    "next": "^11.0.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   }
 }

--- a/navigate-between-pages-starter/package.json
+++ b/navigate-between-pages-starter/package.json
@@ -8,8 +8,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "^10.0.0",
-    "react": "17.0.1",
-    "react-dom": "17.0.1"
+    "next": "^11.0.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2"
   }
 }

--- a/typescript-final/next-env.d.ts
+++ b/typescript-final/next-env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />

--- a/typescript-final/package.json
+++ b/typescript-final/package.json
@@ -17,8 +17,8 @@
     "remark-html": "^12.0.0"
   },
   "devDependencies": {
-    "@types/node": "^13.11.0",
-    "@types/react": "^16.9.32",
-    "typescript": "^3.8.3"
+    "@types/node": "^16.3.3",
+    "@types/react": "^17.0.14",
+    "typescript": "^4.3.5"
   }
 }

--- a/typescript-final/package.json
+++ b/typescript-final/package.json
@@ -11,8 +11,8 @@
     "date-fns": "^2.11.1",
     "gray-matter": "^4.0.2",
     "next": "^11.0.0",
-    "react": "16.13.1",
-    "react-dom": "16.13.1",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "remark": "^12.0.0",
     "remark-html": "^12.0.0"
   },

--- a/typescript-final/package.json
+++ b/typescript-final/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "date-fns": "^2.11.1",
     "gray-matter": "^4.0.2",
-    "next": "^10.0.0",
+    "next": "^11.0.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "remark": "^12.0.0",


### PR DESCRIPTION
This updates to the latest Version of Next.js v11 and also bumps to latest react as well since I noticed these versions were out of date while looking into https://github.com/vercel/next.js/issues/27298